### PR TITLE
add extra protocols

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     network_mode: host
     volumes:
       - ${HIVEMIND_CONFIG_FOLDER}:/home/${HIVEMIND_USER}/.config/hivemind:z
+      - ${HIVEMIND_SERVER_CONFIG_FOLDER}:/home/${HIVEMIND_USER}/.config/hivemind-core:z
       - ${HIVEMIND_SHARE_FOLDER}:/home/${HIVEMIND_USER}/.local/share/hivemind:z
 
   hivemind_cli:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -30,8 +30,9 @@ services:
       TZ: $TZ
     network_mode: host
     volumes:
+      # NOTE: server.conf goes into hivemind-core, identity.json goes into hivemind
       - ${HIVEMIND_CONFIG_FOLDER}:/home/${HIVEMIND_USER}/.config/hivemind:z
-      - ${HIVEMIND_SERVER_CONFIG_FOLDER}:/home/${HIVEMIND_USER}/.config/hivemind-core:z
+      - ${HIVEMIND_CONFIG_FOLDER}:/home/${HIVEMIND_USER}/.config/hivemind-core:z
       - ${HIVEMIND_SHARE_FOLDER}:/home/${HIVEMIND_USER}/.local/share/hivemind:z
 
   hivemind_cli:

--- a/listener/files/requirements.txt
+++ b/listener/files/requirements.txt
@@ -1,4 +1,6 @@
 hivemind-bus-client
 hivemind-core
 hivemind-presence
+hivemind-http-protocol
+hivemind-audio-binary-protocol
 setuptools

--- a/listener/files/requirements.txt
+++ b/listener/files/requirements.txt
@@ -3,4 +3,5 @@ hivemind-core
 hivemind-presence
 hivemind-http-protocol
 hivemind-audio-binary-protocol
+hivemind-redis-database
 setuptools


### PR DESCRIPTION
includes https://github.com/JarbasHiveMind/hivemind-http-protocol and https://github.com/JarbasHiveMind/hivemind-audio-binary-protocol since i expect those to become common

note: a hivemind.list similar to OVOS is needed to allow plugins to be installed for usage with binary protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency management by incorporating new dependencies for HTTP and audio binary protocols.
  - Added a volume mapping for configuration files in the `hivemind_listener` service to improve configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->