### PR TITLE
docs: zero-to-hero README and docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,108 +1,92 @@
-# HiveMind-Docker
+# hivemind-docker
 
-Welcome to **HiveMind-Docker**, the quickest way to hive-mind your way into a distributed, multi-instance Open Voice OS setup. This repository is your one-stop shop for running a HiveMind Node or a HiveMind Hub with the power of Docker or Podman. Think of it as the central nervous system for all your Open Voice OS-enabled devices—but with fewer existential crises and more containers.
+Docker/Podman images and Compose stacks for running a
+[HiveMind](https://github.com/JarbasHiveMind/HiveMind-core) hub or satellite
+alongside an [OpenVoiceOS](https://openvoiceos.com) instance. The repository ships
+a layered image stack and per-service Compose files; the images themselves
+`pip`/`uv pip` install the upstream HiveMind and OVOS packages.
 
-## Why HiveMind-Docker?
+## Where it sits
 
-Because managing a distributed AI system should be as easy as ordering takeout! We package everything you need in neat Docker containers so you can:
+A HiveMind mesh is a central [hivemind-core](https://github.com/JarbasHiveMind/HiveMind-core)
+hub with satellites and bridges connecting to it. This repo containerises those
+roles so a hub, a voice satellite, the CLI, and the chat bridges can be brought up
+with Compose instead of installed by hand.
 
-- Coordinate your Hivemind devices like a boss.
-- Avoid dependency nightmares. (Goodbye, "works on my machine!")
-- Set up your HiveMind faster than it takes to debug a YAML file.
+## Images
+
+| Image | Role |
+| --- | --- |
+| `hivemind-base` | Stack root: `python:3.13-slim` + venv + `uv`, non-root `hivemind` user. |
+| `hivemind-sound-base` | `base` + audio runtime (PulseAudio/PipeWire/ALSA). |
+| `hivemind-listener` | The **hub** — runs `hivemind-core listen` (core + http/audio-binary protocols + redis). |
+| `hivemind-satellite` | Voice satellite (`hivemind-voice-sat`) with OVOS STT/TTS/VAD/WW/mic/PHAL. |
+| `hivemind-cli` | `HiveMind-cli` + core; exec in to run `hivemind-client`. |
+| `hivemind-chatroom`, `hivemind-webchat`, `hivemind-matrix-bot` | Bridge / client surfaces. |
 
 ## Prerequisites
 
-Before you dive into the hive, make sure you have the following:
+- Docker with the Buildx plugin (`docker buildx version`), or a Podman-compatible
+  Compose setup. The Compose files include Podman options (`userns_mode: keep-id`).
+- A decent internet connection for the first image pull.
+- For the satellite: host audio (`/dev/snd`, PulseAudio/PipeWire socket).
 
-1. **Docker** installed on your machine.
-   - Don't have it? [Get Docker](https://www.docker.com/get-started).
-2. **Docker Compose** installed for orchestration.
-   - If you’re not orchestrating, what are you even doing?
-3. A decent internet connection.
-   - Dial-up won’t cut it. Sorry, 1998.
+## Quickstart — run a hub
 
-## Getting Started
-
-### 1. Clone the Repository
-First, grab this repository from GitHub like a honeybee grabbing nectar:
+The published images live under the `smartgic/` registry, so you can run without
+building.
 
 ```bash
-git clone https://github.com/JarbasHiveMind/hivemind-docker.git
-cd hivemind-docker
-```
-
-### 2. Configure Your Environment
-Edit the `.env` file to configure your setup. Here’s an example:
-
-```env
-HIVEMIND_PORT=5678
-HIVEMIND_PASSWORD=SuperSecretPassword
-```
-
-Feel free to use "password123" if you enjoy living dangerously. (Don’t do this. Seriously.)
-
-### 3. Build and Run
-Run the following command to build your containers and start the HiveMind:
-
-```bash
+cd compose
+cp .env-example .env
+# edit .env — at minimum set the config/share folders and timezone
 docker-compose up -d
 ```
 
-This command will:
-- Pull down the necessary images.
-- Deploy your HiveMind containers.
-- Launch your very own AI hive network.
+`compose/docker-compose.yml` starts the **hub** (`hivemind_listener`) and the CLI
+(`hivemind_cli`). To register a satellite client, exec into the CLI container and
+use `hivemind-cli`.
 
-Grab a coffee—or a pint of honey—while Docker works its magic.
+Bring up other roles with their dedicated Compose files:
 
-## Build Images (Buildx Bake)
+```bash
+docker-compose -f docker-compose.satellite.yml up -d   # voice satellite
+docker-compose -f docker-compose.webchat.yml up -d     # browser chat (port 9090)
+docker-compose -f docker-compose.matrix-bot.yml up -d  # Matrix bridge
+docker-compose -f docker-compose.chatroom.yml up -d    # flask chatroom bridge
+```
 
-Builds are handled via Docker Buildx Bake (`docker-bake.hcl` and `scripts/bake.sh`). Direct
-`docker build` usage is not supported because base image wiring relies on Bake contexts.
+## Configuration
 
-### Quick examples
+Runtime config is supplied through `compose/.env` (config/share folders, timezone,
+satellite identity, Matrix credentials). `mycroft.conf.example` is a sample OVOS
+config for the satellite. See [`docs/configuration.md`](docs/configuration.md) for
+the full variable reference and per-service notes.
 
-- Local build (amd64 only, loads to local Docker): `./scripts/bake.sh --load --no-push`
-- Multi-arch publish (default registry/tag): `./scripts/bake.sh`
-- Build a subset: `./scripts/bake.sh -T stack` or `./scripts/bake.sh -T services`
-- Inspect resolved Bake config: `./scripts/bake.sh --print`
-- Disable registry cache: `./scripts/bake.sh --no-cache-from --load --no-push`
+## Building images
 
-### Configuration
+Builds are driven by Docker Buildx Bake (`docker-bake.hcl` + `scripts/bake.sh`).
+Plain `docker build` is not supported — base-image wiring relies on Bake contexts.
 
-Defaults are defined in `docker-bake.hcl` and `scripts/bake.sh`:
+```bash
+./scripts/bake.sh --load --no-push    # local amd64 build into Docker
+./scripts/bake.sh -T stack            # build base + sound-base + listener
+./scripts/bake.sh --print             # show resolved Bake config, no build
+./scripts/bake.sh                      # multi-arch publish (default registry/tag)
+```
 
-- `REGISTRY` (default `docker.io/smartgic`)
-- `TAG` and `VERSION` (default `alpha`)
-- `LATEST_TAG` (default `latest`, only applied when `TAG=stable`)
-- `CHANNEL` (default `alpha`)
-- `PLATFORMS` (default `linux/amd64,linux/arm64`)
-- `UV_PRERELEASE` (default `allow`)
-- `ENSURE_BINFMT` (default `auto`, set `true` to force or `false` to skip)
-- `BUILDER` (default `hivemind-bake`)
+See [`docs/building.md`](docs/building.md) for targets, variables, and multi-arch
+notes.
 
-## Troubleshooting
+## Documentation
 
-1. **Issue: Container won’t start.**
-   - Solution: Check the logs with `docker-compose logs`. They’re like a diary for your containers.
+See [`docs/`](docs/index.md):
 
-2. **Issue: Everything is on fire.**
-   - Solution: Stop, drop, and `docker-compose down`.
-
-## Contributing
-
-Want to make this hive even sweeter? Fork the repo, make your changes, and submit a pull request. Contributions are welcome, but bad puns are mandatory. 🐝
+- [Deploy](docs/deploy.md) — bring up each role, ports, volumes, management.
+- [Compose reference](docs/compose-reference.md) — every Compose file and service.
+- [Configuration](docs/configuration.md) — environment variables.
+- [Building](docs/building.md) — Buildx Bake targets and variables.
 
 ## License
 
-This project is licensed under the MIT License. Basically, do whatever you want, but don’t sue us when your HiveMind becomes sentient and decides to unionize.
-
----
-
-### Disclaimer
-We’re not responsible for:
-- Your HiveMind taking over your smart home.
-- AI existential dilemmas.
-- Containers running away with your CPU.
-
-Enjoy HiveMind-Docker responsibly. And remember: with great power comes great containerization!
+MIT

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,60 @@
+# Building images
+
+Builds use Docker Buildx Bake (`docker-bake.hcl`) via the `scripts/bake.sh`
+wrapper. Plain `docker build` is **not** supported — each child image consumes
+`target:base` / `target:sound-base` through Bake contexts.
+
+## Prerequisites
+
+- Docker with Buildx (`docker buildx version` must succeed).
+- For cross-arch builds, binfmt/qemu (the wrapper installs `tonistiigi/binfmt`
+  automatically unless `--no-binfmt`).
+
+## Targets
+
+Bake groups defined in `docker-bake.hcl`:
+
+| Target | Builds |
+| --- | --- |
+| `default` | all images |
+| `stack` | `base`, `sound-base`, `listener` |
+| `services` | `listener`, `cli`, `chatroom`, `webchat`, `matrix-bot`, `satellite` |
+| `<name>` | a single image target |
+
+## Common commands
+
+```bash
+./scripts/bake.sh --load --no-push     # local amd64 build, load into Docker
+./scripts/bake.sh -T stack             # build the stack group
+./scripts/bake.sh -T listener          # build one target
+./scripts/bake.sh --print              # resolved Bake config, no build
+./scripts/bake.sh                       # multi-arch publish (default registry/tag)
+./scripts/bake.sh --no-cache-from --load --no-push   # disable registry cache
+```
+
+`--load` forces a single-arch `linux/amd64` build and is mutually exclusive with
+`--push`.
+
+## Variables / flags
+
+| Flag | Env | Default | Description |
+| --- | --- | --- | --- |
+| `-r, --registry` | `REGISTRY` | `docker.io/smartgic` | Target registry. |
+| `-t, --tag` | `TAG` | `alpha` | Image tag. |
+| `--latest-tag` | `LATEST_TAG` | `latest` | Extra tag, applied only when `TAG=stable`. |
+| `-v, --version` | `VERSION` | `alpha` | Version label. |
+| `-c, --channel` | `CHANNEL` | `alpha` | Release channel. |
+| `-p, --platforms` | `PLATFORMS` | `linux/amd64,linux/arm64` | Build platforms (CSV). |
+| `-T, --targets` | `TARGETS` | `default` | Bake target(s). |
+| `--no-push` | `PUSH=false` | push by default | Build without pushing. |
+| `--load` | `LOAD=true` | off | Load into local Docker (amd64 only). |
+| `--print` | `PRINT=true` | off | Print resolved config, no build. |
+| `--no-cache-from` | `CACHE_FROM=false` | on | Disable registry cache. |
+| `--ensure-binfmt` / `--no-binfmt` | `ENSURE_BINFMT` | `auto` | Force/skip binfmt install. |
+| `--builder` | `BUILDER` | `hivemind-bake` | Buildx builder name. |
+
+## Notes
+
+- The default publish registry is `docker.io/smartgic`.
+- The base image pins Python by digest; bumping it is a manual Dockerfile edit
+  (Renovate assists).

--- a/docs/compose-reference.md
+++ b/docs/compose-reference.md
@@ -1,0 +1,57 @@
+# Compose reference
+
+All Compose files share YAML anchors for logging (`x-logging`, json-file driver,
+rotation 200 MB / 1 file) and Podman options (`x-podman`, `userns_mode: keep-id`,
+`security_opt: label=disable`). Images are pulled from the `smartgic/` registry at
+the `${VERSION}` tag.
+
+## `docker-compose.yml` — hub
+
+| Service | Image | Network | Volumes |
+| --- | --- | --- | --- |
+| `hivemind_listener` | `smartgic/hivemind-listener:${VERSION}` | host | config (hivemind + hivemind-core), share, `hivemind_local_state` |
+| `hivemind_cli` | `smartgic/hivemind-cli:${VERSION}` | host | config, share; `depends_on: hivemind_listener` |
+
+`server.conf` goes into the hivemind-core config dir; `identity.json` into the
+hivemind config dir (both come from `${HIVEMIND_CONFIG_FOLDER}`).
+
+## `docker-compose.satellite.yml` — voice satellite
+
+| Service | Image | Notes |
+| --- | --- | --- |
+| `hivemind_satellite` | `smartgic/hivemind-satellite:${VERSION}` | `devices: /dev/snd`; mounts PulseAudio/PipeWire sockets and OVOS model/record/cache volumes. |
+| `hivemind_cli` | `smartgic/hivemind-cli:${VERSION}` | management; `depends_on: hivemind_satellite`. |
+
+Identity via `VOICE_SAT_KEY`, `VOICE_SAT_PASSWORD`, `VOICE_SAT_HOST`,
+`VOICE_SAT_PORT`. PulseAudio config via `PULSE_SERVER` / `PULSE_COOKIE` and
+`XDG_RUNTIME_DIR`.
+
+## `docker-compose.webchat.yml`
+
+| Service | Image | Ports |
+| --- | --- | --- |
+| `hivemind_webchat` | `smartgic/hivemind-webchat:${VERSION}` | `9090:9090` |
+
+## `docker-compose.matrix-bot.yml`
+
+| Service | Image | Env |
+| --- | --- | --- |
+| `hivemind_matrix_bot` | `smartgic/hivemind-matrix-bot:${VERSION}` | `MATRIX_BOT_NAME`, `MATRIX_HOST`, `MATRIX_ROOM`, `MATRIX_TOKEN`, plus `VOICE_SAT_*` identity. |
+
+## `docker-compose.chatroom.yml`
+
+| Service | Image | Env |
+| --- | --- | --- |
+| `hivemind_chatroom` | `smartgic/hivemind-chatroom:${VERSION}` | `SAT_KEY`, `SAT_PASSWORD`, `SAT_HOST`, `SAT_PORT`. |
+
+> The chatroom service reads `SAT_*` variables, while `matrix-bot` and `satellite`
+> read `VOICE_SAT_*`. Match the variable names to the Compose file you run.
+
+## Named volumes
+
+| Volume | Used by | Purpose |
+| --- | --- | --- |
+| `hivemind_local_state` | hub | `~/.local/state/hivemind`. |
+| `ovos_models` | satellite | wake-word / precise-lite models. |
+| `ovos_listener_records` | satellite | listener recordings. |
+| `ovos_tts_cache` | satellite | TTS / OVOS cache. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,49 @@
+# Configuration
+
+Runtime configuration is supplied through `compose/.env` (copy from
+`compose/.env-example`). Image build configuration is covered in
+[building.md](building.md).
+
+## Environment variables
+
+| Variable | Example | Used by |
+| --- | --- | --- |
+| `VERSION` | `alpha` | Image tag pulled by every service. |
+| `TZ` | `America/Montreal` | Container timezone. |
+| `HIVEMIND_CONFIG_FOLDER` | `~/hivemind/config` | Host path for hivemind config (`server.conf`, `identity.json`). |
+| `HIVEMIND_SHARE_FOLDER` | `~/hivemind/share` | Host path for hivemind share data. |
+| `HIVEMIND_USER` | `hivemind` | In-container user (volume mount paths). |
+| `HIVEMIND_SITEID` | `voice-sat-1` | Site id for the node. |
+| `OVOS_CONFIG_FOLDER` | `~/ovos/config` | Host path for OVOS config (satellite). |
+| `XDG_RUNTIME_DIR` | `/run/user/1000` | Audio socket runtime dir (satellite). |
+| `VOICE_SAT_KEY` | hex string | Satellite access key. |
+| `VOICE_SAT_PASSWORD` | hex string | Satellite password. |
+| `VOICE_SAT_HOST` | `ws://192.168.100.55` | Hub address the satellite connects to. |
+| `VOICE_SAT_PORT` | `5678` | Hub port. |
+| `MATRIX_BOT_NAME` | `hivemind-bot` | Matrix bridge bot name. |
+| `MATRIX_HOST` | `https://matrix.org` | Matrix homeserver. |
+| `MATRIX_ROOM` | `#hivemind-bots:matrix.org` | Matrix room. |
+| `MATRIX_TOKEN` | `syt_XXXX` | Matrix access token. |
+
+> The chatroom service uses `SAT_KEY` / `SAT_PASSWORD` / `SAT_HOST` / `SAT_PORT`
+> instead of the `VOICE_SAT_*` names — set whichever the running Compose file
+> reads.
+
+## OVOS config
+
+`mycroft.conf.example` is a sample OVOS configuration for the satellite (logging,
+language, VAD plugin, hotwords). Copy it into `${OVOS_CONFIG_FOLDER}` as
+`mycroft.conf` and adjust.
+
+## Identity provisioning
+
+The satellite/bridge identities (`VOICE_SAT_KEY` / `VOICE_SAT_PASSWORD`) must first
+be registered as clients on the hub. Exec into the CLI container and add the client
+there before starting the satellite.
+
+## Runtime plugin install
+
+The `satellite` and `listener` entrypoints self-install extra plugins at runtime
+from `satellite.list` / `listener.list` (diffed against a `.state` file), so first
+boot may pip-install on the device. The `tflite_runtime` install in the satellite
+is best-effort.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,76 @@
+# Deploy
+
+All Compose files live in `compose/`. They reference published images under the
+`smartgic/` registry, so deployment does not require a local build.
+
+## Setup
+
+```bash
+cd compose
+cp .env-example .env
+# edit .env (see configuration.md)
+```
+
+## Roles
+
+| Compose file | Brings up | Notes |
+| --- | --- | --- |
+| `docker-compose.yml` | `hivemind_listener` (hub) + `hivemind_cli` | The default hub stack. |
+| `docker-compose.satellite.yml` | `hivemind_satellite` + `hivemind_cli` | Needs host audio + identity. |
+| `docker-compose.webchat.yml` | `hivemind_webchat` | Browser chat on port 9090. |
+| `docker-compose.matrix-bot.yml` | `hivemind_matrix_bot` | Matrix bridge. |
+| `docker-compose.chatroom.yml` | `hivemind_chatroom` | Flask chatroom bridge. |
+
+Start a role:
+
+```bash
+docker-compose -f docker-compose.yml up -d
+docker-compose -f docker-compose.satellite.yml up -d
+```
+
+## Networking and ports
+
+Most services run with `network_mode: host`, so they bind directly on the host:
+
+- **Hub (`hivemind_listener`)** — `5678` (WebSocket). The HTTP/audio-binary
+  protocols listen on their own ports when enabled.
+- **Webchat** — published `9090:9090`.
+
+Because the hub and CLI use host networking, the CLI reaches the hub on
+`localhost`.
+
+## Volumes
+
+The hub stack persists config, share, and local state:
+
+- `${HIVEMIND_CONFIG_FOLDER}` → `~/.config/hivemind` and `~/.config/hivemind-core`
+  (holds `server.conf` and `identity.json`).
+- `${HIVEMIND_SHARE_FOLDER}` → `~/.local/share/hivemind`.
+- A named volume `hivemind_local_state` → `~/.local/state/hivemind`.
+
+The satellite additionally mounts the host audio sockets (`/dev/snd`, the
+PulseAudio/PipeWire runtime sockets) and named volumes for OVOS models, listener
+records, and the TTS cache.
+
+## Management commands
+
+```bash
+# follow logs
+docker-compose logs -f hivemind_listener
+
+# stop / restart
+docker-compose down
+docker-compose restart hivemind_listener
+
+# register a satellite client (exec into the CLI container)
+docker exec -it ovos_hivemind_cli hivemind-cli add-client
+```
+
+(`hivemind-cli` exposes the client management subcommands; the CLI container runs
+`sleep infinity` so you exec into it.)
+
+## SSL
+
+The images serve plain WebSocket by default. To expose the hub over TLS, terminate
+SSL in front of it with a reverse proxy, or configure `hivemind-core`'s own SSL
+options and mount the certificates via the config volume.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# hivemind-docker
+
+Docker/Podman images and Compose stacks for running a HiveMind hub or satellite
+alongside an OpenVoiceOS instance.
+
+- [Deploy](deploy.md)
+- [Compose reference](compose-reference.md)
+- [Configuration](configuration.md)
+- [Building](building.md)
+
+## Where it sits
+
+The repo containerises the roles of a [HiveMind](https://github.com/JarbasHiveMind/HiveMind-core)
+mesh: the central hub (`hivemind-listener`), a voice satellite, the CLI, and the
+chat bridges. Images install upstream HiveMind and OVOS packages — there is no
+application source of its own in this repo.
+
+## Layout
+
+- `docker-bake.hcl` — Buildx Bake image definitions.
+- `scripts/bake.sh` — Bake wrapper (flag parsing, binfmt/qemu, push/load/print).
+- `base/`, `sound-base/` — the image stack roots.
+- `listener/`, `satellite/`, `cli/`, `chatroom/`, `webchat/`, `matrix-bot/` — the
+  per-role images (`Dockerfile` + `files/`).
+- `compose/` — per-service `docker-compose.*.yml` and `.env-example`.
+- `mycroft.conf.example` — sample OVOS config for the satellite.


### PR DESCRIPTION
Brings the README and `docs/` to zero-to-hero quality for hivemind-docker.

- Rewrites the README to remove meta-commentary/jokes/emojis and describe the current state accurately: tagline, where it sits in a HiveMind mesh, the image table, prereqs, quickstart (compose up a hub), other roles, Buildx Bake build commands, configuration + docs pointers.
- Adds `docs/`: deploy (roles, ports, volumes, management, SSL), compose-reference (every compose file + service + named volume), configuration (env vars), building (Bake targets/flags/variables).

Base branch is `feat/initial` — confirmed as the repo's GitHub default branch (no `master`; a stale `dev` exists but is not the default and is behind). No CI/release workflows present on this branch.

Docs only — no code, version, or workflow changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
