### PR TITLE
feat(images): constraints-pinned installs, Python 3.13.15, exec entrypoints, healthchecks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,15 +22,17 @@ the wire protocol and specs live in the architecture docs.
 
 ## Layout / build / test
 
-- `base/Dockerfile` — Debian bookworm-slim + a `hivemind` user venv; parent
-  image for everything else.
+- `base/Dockerfile` — digest-pinned `python:3.13-slim-trixie` (one `PYTHON_IMAGE`
+  arg feeds FROM and the `base.name` label) + a `hivemind` user venv with a
+  pinned static `uv`; parent image for everything else.
 - `sound-base/Dockerfile` — adds PulseAudio/PipeWire/ALSA tooling on top of
   `base`, for audio-capable images.
-- `cli/Dockerfile` + `cli/files/requirements.txt` — installs `HiveMind-cli`
-  and `HiveMind-core` from git; entrypoint is `sleep infinity` (exec into it).
+- `cli/Dockerfile` + `cli/files/requirements.txt` — installs `hivemind-cli`
+  and `hivemind-core` from PyPI; entrypoint is `sleep infinity` (exec into it).
 - `listener/Dockerfile` + `listener/files/requirements.txt` — installs
-  `hivemind_bus_client`, `HiveMind-core` (from git), and `HiveMind-presence`;
-  entrypoint is `hivemind-core listen`.
+  `hivemind-core` and its protocol stack from PyPI; the entrypoint execs
+  `hivemind-core listen` and the image healthchecks its own websocket
+  handshake on `${HIVEMIND_PORT:-5678}`.
 - `satellite/Dockerfile` + `satellite/files/{requirements.txt,entrypoint.sh}`
   — built on `sound-base`; installs `HiveMind-voice-sat` and OVOS
   audio/STT/TTS/VAD/wake-word plugins; the entrypoint script installs any
@@ -44,10 +46,12 @@ the wire protocol and specs live in the architecture docs.
   say so plainly rather than inventing one. Validate a change by actually
   building the affected image (`docker build -t test ./listener` etc.) and,
   where practical, bringing the compose stack up against a real or test hub.
-- Each Dockerfile takes `ARG TAG=alpha` (which base-image tag to build from)
-  and `ARG ALPHA=false` (whether to `pip install --pre`). Building
-  `listener`/`cli`/`satellite` requires the corresponding base image to exist
-  locally or be pullable first.
+- Each Dockerfile takes `ARG TAG=alpha` (which base-image tag to build from),
+  `ARG CHANNEL` + `ARG OVOS_RELEASES_REF` (which
+  `constraints-<channel>.txt` from OpenVoiceOS/ovos-releases pins the
+  installs) and `ARG UV_PRERELEASE` (uv prerelease policy; `allow` on the
+  alpha channel). Bake's `contexts` wire the base images, so build through
+  `docker buildx bake` / `scripts/bake.sh`, not `docker build`.
 
 ## Working agreement (org-wide law)
 
@@ -77,18 +81,15 @@ the wire protocol and specs live in the architecture docs.
 
 ## Dependencies
 
-- **Floor pins only** (`>=X.Y.Za1`), bumped when a feature or fix is actually
-  needed — with a one-line comment saying why. No upper caps unless a specific
-  released version is genuinely broken (say which and why).
-- **No lockfiles, ever.** These images target the latest alphas
-  (`ALPHA=true` builds with `pip install --pre`); prefer `uv` over bare `pip`
-  in any Dockerfile RUN step you touch, if the base image has it available.
-- Python package pins live in each image's `files/requirements.txt`, not in a
-  root manifest — this repo has no `pyproject.toml`/`package.json` of its own.
-  `listener` and `cli` currently install `HiveMind-core`/`HiveMind-cli`
-  straight from GitHub (`git+https://...`); prefer a published PyPI alpha
-  when practical, but do not silently rewrite this without confirming a
-  released alpha actually exists.
+- **Versions come from the channel constraints file**, not from manual pins:
+  every install runs `uv pip install -c /tmp/constraints.txt` against
+  `constraints-<channel>.txt` from OpenVoiceOS/ovos-releases, the resolved,
+  mutually-consistent set for that channel. `files/requirements.txt` lists
+  bare package names (what the image contains); add a floor or pin there only
+  when a specific released version is genuinely broken, with a one-line
+  comment saying which and why (see matrix-bot).
+- **No lockfiles.** Prerelease policy is the `UV_PRERELEASE` build arg
+  (`allow` on alpha); prefer `uv` over bare `pip` in any RUN step you touch.
 - Apache-2.0. Do not add GPL/AGPL dependencies.
 
 ## Tests

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,11 +1,15 @@
-# syntax=docker/dockerfile:1.7
-FROM python:3.13.11-slim-trixie@sha256:56ab277ddf459858f94052252565945c34617c841818faf8f34f6896de06cffe
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
+# One reference for FROM and the base.name label, so a Renovate bump updates both.
+ARG PYTHON_IMAGE=python:3.13.15-slim-trixie@sha256:7ce4b6dfe35e55397b7cda544f8a13f191b7ae28dc5aad71fe664dbc9bc2623f
+FROM ${PYTHON_IMAGE}
+ARG PYTHON_IMAGE
 
 ARG BUILD_DATE=unknown
 ARG CHANNEL=alpha
 ARG VERSION=unknown
 ARG IMAGE_REF=hivemind-base:alpha
 ARG GIT_SHA=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI base image" \
       org.opencontainers.image.description="Used as base layer for other OCI images" \
@@ -16,20 +20,28 @@ LABEL org.opencontainers.image.title="HiveMind OCI base image" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="python:3.13.11-slim-trixie@sha256:56ab277ddf459858f94052252565945c34617c841818faf8f34f6896de06cffe" \
+      org.opencontainers.image.base.name="${PYTHON_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${IMAGE_REF}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
 ARG USER=hivemind
 ARG USER_UID=1000
 ARG USER_GID=1000
 
+# uv as a pinned static binary (Renovate tracks the image reference); no unpinned "pip install uv"
+COPY --from=ghcr.io/astral-sh/uv:0.12.7@sha256:95f2aa1fe59274951cfe9b0cbc7972e879ff1004bc8945d130a32eb0dbd85945 /uv /uvx /usr/local/bin/
+
+# MALLOC_ARENA_MAX=2: the services are heavily threaded; fewer glibc arenas means less RSS on small devices.
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    MALLOC_ARENA_MAX=2
 
 SHELL ["/bin/bash", "-c"]
 
@@ -51,12 +63,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     fi \
  && rm -rf /var/log/{apt,dpkg.log} /tmp/* /var/tmp/*
 
-RUN --mount=type=cache,target=/root/.cache/pip \
+# The venv keeps the pip bundled with the (digest-pinned) Python image. setuptools is still needed
+# at runtime by packages using pkg_resources; pinned like ovos-installer does (setuptools<82).
+# Bytecode is compiled at install time (UV_COMPILE_BYTECODE) so services start fast on small
+# devices; PYTHONDONTWRITEBYTECODE keeps the running container from writing .pyc files.
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     groupadd --gid "$USER_GID" "$USER" \
  && useradd --no-log-init --uid "$USER_UID" --gid "$USER_GID" -m -c "HiveMind user" "$USER" \
  && python -m venv "/home/${USER}/.venv" \
  && source "/home/${USER}/.venv/bin/activate" \
- && PIP_NO_CACHE_DIR=0 pip install --upgrade pip setuptools wheel uv \
+ && uv pip install "setuptools<82" \
  && mkdir -p "/home/${USER}"/.{config,cache,local/{state,share}}/{hivemind,hivemind-core,mycroft} \
  && chown "${USER}:${USER}" -R "/home/${USER}"
 

--- a/chatroom/Dockerfile
+++ b/chatroom/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG TAG=alpha
 ARG REGISTRY=docker.io/smartgic
 ARG BASE_IMAGE=${REGISTRY}/hivemind-base:${TAG}
@@ -20,14 +20,20 @@ LABEL org.opencontainers.image.title="HiveMind OCI Chatroom" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="${REGISTRY}/hivemind-base:${TAG}" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${REGISTRY}/hivemind-chatroom:${TAG}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
-ARG ALPHA=false
+ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
+ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
+
+# The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD
+# checksums the remote file, so the layer cache busts exactly when the constraints change.
+ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${CHANNEL}.txt /tmp/constraints.txt
 
 COPY --chmod=0755 files/entrypoint.sh /usr/local/bin/entrypoint.sh
 
@@ -36,12 +42,13 @@ USER root
 SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
-    PRERELEASE="${UV_PRERELEASE}" \
- && if [ "${ALPHA}" = "true" ]; then PRERELEASE="allow"; fi \
- && uv pip install --prerelease="${PRERELEASE}" hivemind-flask-chatroom==0.1.0 \
+    uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt "hivemind-flask-chatroom>=0.1.0" \
  && rm -rf /tmp/* /var/tmp/*
 
 USER "$USER"
+
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=30s \
+  CMD curl -sf http://127.0.0.1:8985/ > /dev/null || exit 1
 
 ENTRYPOINT ["/bin/bash", "/usr/local/bin/entrypoint.sh"]
 

--- a/chatroom/files/entrypoint.sh
+++ b/chatroom/files/entrypoint.sh
@@ -26,4 +26,4 @@ if ! hivemind_set_identity "$SAT_KEY" "$SAT_PASSWORD" "$SAT_HOST" "$SAT_PORT"; t
     exit 1
 fi
 
-hivemind-flask-chatroom
+exec hivemind-flask-chatroom

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG TAG=alpha
 ARG REGISTRY=docker.io/smartgic
 ARG BASE_IMAGE=${REGISTRY}/hivemind-base:${TAG}
@@ -20,14 +20,20 @@ LABEL org.opencontainers.image.title="HiveMind OCI CLI image" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="${REGISTRY}/hivemind-base:${TAG}" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${REGISTRY}/hivemind-cli:${TAG}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
-ARG ALPHA=false
+ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
+ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
+
+# The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD
+# checksums the remote file, so the layer cache busts exactly when the constraints change.
+ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${CHANNEL}.txt /tmp/constraints.txt
 
 COPY files/requirements.txt /tmp/requirements.txt
 
@@ -41,9 +47,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
       vim nano python3-dev build-essential libxml2-dev libxslt1-dev \
- && PRERELEASE="${UV_PRERELEASE}" \
- && if [ "${ALPHA}" = "true" ]; then PRERELEASE="allow"; fi \
- && uv pip install --prerelease="${PRERELEASE}" -r /tmp/requirements.txt \
+ && uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt -r /tmp/requirements.txt \
  && mkdir -p \
       "/home/${USER}/.config/hivemind" \
       "/home/${USER}/.local/share/hivemind-core" \

--- a/cli/files/requirements.txt
+++ b/cli/files/requirements.txt
@@ -1,7 +1,4 @@
-# hivemind-cli 0.5.1a1 jumped to ovos-bus-client 2.x, which no released
-# hivemind-core supports yet (core is still 1.x; see core#108). Pin 0.5.0a4,
-# the latest CLI alpha still on bus-client <2.0.0, so it co-installs with
-# hivemind-core 4.6.0a2.
-hivemind-cli==0.5.0a4
-hivemind-core==4.6.0a2
+hivemind-cli
+# admin console: the hub's own CLI (add-client, list-clients, ...) next to hivemind-cli
+hivemind-core
 lxml>=5.1.0

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,249 +1,175 @@
-group "default" {
-  targets = [
-    "base",
-    "sound-base",
-    "listener",
-    "cli",
-    "chatroom",
-    "webchat",
-    "matrix-bot",
-    "satellite",
-  ]
-}
-
-group "stack" {
-  targets = ["base", "sound-base", "listener"]
-}
-
-group "services" {
-  targets = [
-    "listener",
-    "cli",
-    "chatroom",
-    "webchat",
-    "matrix-bot",
-    "satellite",
-  ]
-}
+# docker-bake.hcl — HiveMind container images
+#
+#   ./scripts/bake.sh                       multi-arch build + push of the "default" group
+#   ./scripts/bake.sh -T listener --load    local single-arch build of one target
+#   docker buildx bake --print services     show the resolved configuration of a group
+#
+# Image graph:
+#   base ─┬─ sound-base ─ satellite
+#         └─ listener, cli, chatroom, webchat, matrix-bot
 
 # ---------- Variables (override via env or scripts/bake.sh) ----------
-variable "REGISTRY"   { default = "docker.io/smartgic" }
-variable "TAG"        { default = "alpha" }
-variable "LATEST_TAG" { default = "latest" }
-variable "CHANNEL"    { default = "alpha" }
-variable "UV_PRERELEASE" { default = "allow" }
-variable "VERSION"    { default = "alpha" }
-variable "BUILD_DATE" { default = "1970-01-01T00:00:00Z" }
-variable "GIT_SHA"    { default = "unknown" }
+variable "REGISTRY"          { default = "docker.io/smartgic" }
+variable "TAG"               { default = "alpha" }
+variable "LATEST_TAG"        { default = "latest" }
+variable "CHANNEL"           { default = "alpha" }
+variable "UV_PRERELEASE"     { default = "allow" }
+variable "VERSION"           { default = "alpha" }
+variable "BUILD_DATE"        { default = "1970-01-01T00:00:00Z" }
+variable "GIT_SHA"           { default = "unknown" }
+# Git ref (branch, tag or commit SHA) of OpenVoiceOS/ovos-releases to take constraints-${CHANNEL}.txt from.
+# Passing a commit SHA makes the build reproducible and busts the layer cache when the constraints change.
+variable "OVOS_RELEASES_REF" { default = "main" }
+
+# Build cache. Lives on GHCR (no pull-rate limits, free for public repositories) as one tag per
+# image and TAG, so channels and architectures never share cache entries. CACHE_TO="max" exports
+# the cache after the build (CI); leave it empty for local builds without GHCR write access —
+# cache-from still works anonymously because the cache package is public.
+variable "CACHE_REPO" { default = "ghcr.io/jarbashivemind/hivemind-docker-cache" }
+variable "CACHE_TO"   { default = "" }
+
+# Optional second registry every image is also pushed to (CI uses ghcr.io/jarbashivemind/hivemind-docker,
+# sub-namespaced so the packages can never collide with the ones other JarbasHiveMind repositories
+# publish). The pipeline reads manifests, labels and SBOMs from there, which has no pull-rate limit;
+# users keep pulling from REGISTRY. Empty = single registry (local builds).
+variable "MIRROR_REGISTRY" { default = "" }
+
+# ---------- Helpers ----------
+# stable is additionally tagged LATEST_TAG; every other TAG is published as-is.
+# With MIRROR_REGISTRY set, the same tags are also produced for the mirror.
+function "tags" {
+  params = [image]
+  result = compact(concat(
+    TAG == "stable" ? [
+      "${REGISTRY}/${image}:${TAG}",
+      "${REGISTRY}/${image}:${LATEST_TAG}",
+    ] : [
+      "${REGISTRY}/${image}:${TAG}",
+    ],
+    MIRROR_REGISTRY == "" ? [""] : (TAG == "stable" ? [
+      "${MIRROR_REGISTRY}/${image}:${TAG}",
+      "${MIRROR_REGISTRY}/${image}:${LATEST_TAG}",
+    ] : [
+      "${MIRROR_REGISTRY}/${image}:${TAG}",
+    ]),
+  ))
+}
+
+function "cache_from" {
+  params = [image]
+  result = ["type=registry,ref=${CACHE_REPO}:${image}-${TAG}"]
+}
+
+function "cache_to" {
+  params = [image]
+  result = compact([CACHE_TO == "" ? "" : "type=registry,ref=${CACHE_REPO}:${image}-${TAG},mode=${CACHE_TO}"])
+}
+
+# ---------- Groups ----------
+group "default"  { targets = ["stack", "services"] }
+group "stack"    { targets = ["base", "sound-base", "listener"] }
+group "services" { targets = ["listener", "cli", "chatroom", "webchat", "matrix-bot", "satellite"] }
 
 # ---------- Common settings ----------
 target "common" {
-  platforms = ["linux/amd64","linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64"]
 
   args = {
-    BUILD_DATE    = "${BUILD_DATE}"
-    VERSION       = "${VERSION}"
-    CHANNEL       = "${CHANNEL}"
-    TAG           = "${TAG}"
-    REGISTRY      = "${REGISTRY}"
-    GIT_SHA       = "${GIT_SHA}"
-    OVOS_CHANNEL  = "${CHANNEL}"
-    UV_PRERELEASE = "${UV_PRERELEASE}"
+    BUILD_DATE        = "${BUILD_DATE}"
+    VERSION           = "${VERSION}"
+    CHANNEL           = "${CHANNEL}"
+    TAG               = "${TAG}"
+    REGISTRY          = "${REGISTRY}"
+    GIT_SHA           = "${GIT_SHA}"
+    OVOS_CHANNEL      = "${CHANNEL}"
+    UV_PRERELEASE     = "${UV_PRERELEASE}"
+    OVOS_RELEASES_REF = "${OVOS_RELEASES_REF}"
   }
 
-  # SBOM + provenance
+  # SBOM + provenance, embedded in the image index
   attest = [
     { type = "provenance", mode = "max", inline = true },
-    { type = "sbom", inline = true }
+    { type = "sbom", inline = true },
   ]
 }
 
-# ---------- base (context = ./base) ----------
+# ---------- Base images ----------
 target "base" {
   inherits   = ["common"]
   context    = "base"
-  dockerfile = "Dockerfile"
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-base:${TAG}",
-    "${REGISTRY}/hivemind-base:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-base:${TAG}",
-  ]
-  args = {
-    IMAGE_REF = "hivemind-base:${TAG}"
-  }
-
-  # Inline cache works with any registry
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-base:${TAG}"]
-  cache-to   = ["type=inline"]
+  tags       = tags("hivemind-base")
+  args       = { IMAGE_REF = "hivemind-base:${TAG}" }
+  cache-from = cache_from("hivemind-base")
+  cache-to   = cache_to("hivemind-base")
 }
 
-# ---------- sound-base (context = ./sound-base) ----------
 target "sound-base" {
   inherits   = ["common"]
   context    = "sound-base"
-  dockerfile = "Dockerfile"
-  depends_on = ["base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-sound-base:${TAG}",
-    "${REGISTRY}/hivemind-sound-base:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-sound-base:${TAG}",
-  ]
-  # Map Dockerfile's BASE_IMAGE name to locally-built base target
-  contexts = {
-    "hivemind-base" = "target:base"
-  }
-
-  args = {
-    BASE_IMAGE = "hivemind-base"
-    IMAGE_REF  = "hivemind-sound-base:${TAG}"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-sound-base:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-base" = "target:base" }
+  tags       = tags("hivemind-sound-base")
+  args       = { BASE_IMAGE = "hivemind-base", IMAGE_REF = "hivemind-sound-base:${TAG}" }
+  cache-from = cache_from("hivemind-sound-base")
+  cache-to   = cache_to("hivemind-sound-base")
 }
 
-# ---------- listener (context = ./listener) ----------
+# ---------- Services ----------
 target "listener" {
   inherits   = ["common"]
   context    = "listener"
-  dockerfile = "Dockerfile"
-  depends_on = ["base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-listener:${TAG}",
-    "${REGISTRY}/hivemind-listener:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-listener:${TAG}",
-  ]
-  contexts = {
-    "hivemind-base" = "target:base"
-  }
-
-  args = {
-    BASE_IMAGE = "hivemind-base"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-listener:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-base" = "target:base" }
+  tags       = tags("hivemind-listener")
+  args       = { BASE_IMAGE = "hivemind-base" }
+  cache-from = cache_from("hivemind-listener")
+  cache-to   = cache_to("hivemind-listener")
 }
 
-# ---------- cli (context = ./cli) ----------
 target "cli" {
   inherits   = ["common"]
   context    = "cli"
-  dockerfile = "Dockerfile"
-  depends_on = ["base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-cli:${TAG}",
-    "${REGISTRY}/hivemind-cli:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-cli:${TAG}",
-  ]
-  contexts = {
-    "hivemind-base" = "target:base"
-  }
-
-  args = {
-    BASE_IMAGE = "hivemind-base"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-cli:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-base" = "target:base" }
+  tags       = tags("hivemind-cli")
+  args       = { BASE_IMAGE = "hivemind-base" }
+  cache-from = cache_from("hivemind-cli")
+  cache-to   = cache_to("hivemind-cli")
 }
 
-# ---------- chatroom (context = ./chatroom) ----------
 target "chatroom" {
   inherits   = ["common"]
   context    = "chatroom"
-  dockerfile = "Dockerfile"
-  depends_on = ["base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-chatroom:${TAG}",
-    "${REGISTRY}/hivemind-chatroom:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-chatroom:${TAG}",
-  ]
-  contexts = {
-    "hivemind-base" = "target:base"
-  }
-
-  args = {
-    BASE_IMAGE = "hivemind-base"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-chatroom:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-base" = "target:base" }
+  tags       = tags("hivemind-chatroom")
+  args       = { BASE_IMAGE = "hivemind-base" }
+  cache-from = cache_from("hivemind-chatroom")
+  cache-to   = cache_to("hivemind-chatroom")
 }
 
-# ---------- webchat (context = ./webchat) ----------
 target "webchat" {
   inherits   = ["common"]
   context    = "webchat"
-  dockerfile = "Dockerfile"
-  depends_on = ["base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-webchat:${TAG}",
-    "${REGISTRY}/hivemind-webchat:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-webchat:${TAG}",
-  ]
-  contexts = {
-    "hivemind-base" = "target:base"
-  }
-
-  args = {
-    BASE_IMAGE = "hivemind-base"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-webchat:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-base" = "target:base" }
+  tags       = tags("hivemind-webchat")
+  args       = { BASE_IMAGE = "hivemind-base" }
+  cache-from = cache_from("hivemind-webchat")
+  cache-to   = cache_to("hivemind-webchat")
 }
 
-# ---------- matrix-bot (context = ./matrix-bot) ----------
 target "matrix-bot" {
   inherits   = ["common"]
   context    = "matrix-bot"
-  dockerfile = "Dockerfile"
-  depends_on = ["base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-matrix-bot:${TAG}",
-    "${REGISTRY}/hivemind-matrix-bot:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-matrix-bot:${TAG}",
-  ]
-  contexts = {
-    "hivemind-base" = "target:base"
-  }
-
-  args = {
-    BASE_IMAGE = "hivemind-base"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-matrix-bot:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-base" = "target:base" }
+  tags       = tags("hivemind-matrix-bot")
+  args       = { BASE_IMAGE = "hivemind-base" }
+  cache-from = cache_from("hivemind-matrix-bot")
+  cache-to   = cache_to("hivemind-matrix-bot")
 }
 
-# ---------- satellite (context = ./satellite) ----------
 target "satellite" {
   inherits   = ["common"]
   context    = "satellite"
-  dockerfile = "Dockerfile"
-  depends_on = ["sound-base"]
-  tags = TAG == "stable" ? [
-    "${REGISTRY}/hivemind-satellite:${TAG}",
-    "${REGISTRY}/hivemind-satellite:${LATEST_TAG}",
-  ] : [
-    "${REGISTRY}/hivemind-satellite:${TAG}",
-  ]
-  contexts = {
-    "hivemind-sound-base" = "target:sound-base"
-  }
-
-  args = {
-    SOUND_BASE_IMAGE = "hivemind-sound-base"
-  }
-
-  cache-from = ["type=registry,ref=${REGISTRY}/hivemind-satellite:${TAG}"]
-  cache-to   = ["type=inline"]
+  contexts   = { "hivemind-sound-base" = "target:sound-base" }
+  tags       = tags("hivemind-satellite")
+  args       = { SOUND_BASE_IMAGE = "hivemind-sound-base" }
+  cache-from = cache_from("hivemind-satellite")
+  cache-to   = cache_to("hivemind-satellite")
 }

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG TAG=alpha
 ARG REGISTRY=docker.io/smartgic
 ARG BASE_IMAGE=${REGISTRY}/hivemind-base:${TAG}
@@ -20,14 +20,20 @@ LABEL org.opencontainers.image.title="HiveMind OCI HiveMind listener" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="${REGISTRY}/hivemind-base:${TAG}" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${REGISTRY}/hivemind-listener:${TAG}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
-ARG ALPHA=false
+ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
+ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
+
+# The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD
+# checksums the remote file, so the layer cache busts exactly when the constraints change.
+ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${CHANNEL}.txt /tmp/constraints.txt
 
 COPY files/requirements.txt /tmp/requirements.txt
 COPY --chmod=0755 files/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -43,8 +49,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
  && apt-get install -o Dpkg::Options::="--force-confold" -y --no-install-recommends --no-install-suggests \
       build-essential python3-dev \
- && PRERELEASE="${UV_PRERELEASE}" \
- && if [ "${ALPHA}" = "true" ]; then PRERELEASE="allow"; fi \
  && if [ -s /run/secrets/github_token ]; then \
       printf '%s\n' \
         '#!/bin/sh' \
@@ -55,7 +59,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       && chmod 0700 /tmp/git-askpass \
       && export GIT_ASKPASS=/tmp/git-askpass GIT_TERMINAL_PROMPT=0; \
     fi \
- && uv pip install --prerelease="${PRERELEASE}" -r /tmp/requirements.txt \
+ && uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt -r /tmp/requirements.txt \
  && rm -f /tmp/git-askpass \
  && mkdir -p \
       "/home/${USER}/.config/hivemind" \
@@ -70,6 +74,12 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 USER "$USER"
 
+# A successful websocket handshake proves hivemind-core is accepting connections.
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=60s \
+  CMD python -c 'import os, websocket; websocket.create_connection("ws://127.0.0.1:%s" % os.environ.get("HIVEMIND_PORT", "5678"), timeout=5).close()' || exit 1
+
 ENTRYPOINT ["/bin/bash", "/usr/local/bin/entrypoint.sh"]
 
 WORKDIR "/home/${USER}"
+
+EXPOSE 5678

--- a/listener/files/entrypoint.sh
+++ b/listener/files/entrypoint.sh
@@ -15,8 +15,5 @@ if test -f "$listener_list"; then
     fi
 fi
 
-# Run hivemind-core
-if ! hivemind-core listen; then
-    echo "Error: Failed to start hivemind-core"
-    exit 1
-fi
+# Run hivemind-core as PID 1 so container signals reach it directly
+exec hivemind-core listen

--- a/listener/files/requirements.txt
+++ b/listener/files/requirements.txt
@@ -1,11 +1,9 @@
 hivemind-bus-client
-hivemind-core==4.6.0a2
-# plugin-manager + websocket transport are pulled in (and version-constrained)
-# transitively by hivemind-core; declared here too so the bundled image is
-# explicit about its protocol stack.
+hivemind-core
+# plugin-manager + transports are pulled in (and version-constrained) transitively by
+# hivemind-core; declared here too so the bundled image is explicit about its protocol stack.
 hivemind-plugin-manager
 hivemind-websocket-protocol
 hivemind-http-protocol
 hivemind-audio-binary-protocol
-hivemind-redis-database==0.1.0a7
-setuptools
+hivemind-redis-database

--- a/matrix-bot/Dockerfile
+++ b/matrix-bot/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG TAG=alpha
 ARG REGISTRY=docker.io/smartgic
 ARG BASE_IMAGE=${REGISTRY}/hivemind-base:${TAG}
@@ -20,14 +20,20 @@ LABEL org.opencontainers.image.title="HiveMind OCI Matrix bot" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="${REGISTRY}/hivemind-base:${TAG}" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${REGISTRY}/hivemind-matrix-bot:${TAG}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
-ARG ALPHA=false
+ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
+ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
+
+# The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD
+# checksums the remote file, so the layer cache busts exactly when the constraints change.
+ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${CHANNEL}.txt /tmp/constraints.txt
 
 COPY files/requirements.txt /tmp/requirements.txt
 COPY --chmod=0755 files/entrypoint.sh /usr/local/bin/entrypoint.sh
@@ -37,9 +43,7 @@ USER root
 SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
-    PRERELEASE="${UV_PRERELEASE}" \
- && if [ "${ALPHA}" = "true" ]; then PRERELEASE="allow"; fi \
- && uv pip install --prerelease="${PRERELEASE}" -r /tmp/requirements.txt \
+    uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt -r /tmp/requirements.txt \
  && rm -rf /tmp/* /var/tmp/*
 
 USER "$USER"

--- a/matrix-bot/files/entrypoint.sh
+++ b/matrix-bot/files/entrypoint.sh
@@ -34,12 +34,8 @@ function run_matrix() {
     local matrixhost=$3
     local room=$4
 
-    if ! HiveMind-matrix run --botname "$botname" --matrixtoken "$matrixtoken" --matrixhost "$matrixhost" --room "$room"; then
-        echo "Error: Failed to start Matrix bot."
-        return 1
-    fi
-
-    return 0
+    # exec: the bot becomes PID 1 so container signals reach it directly
+    exec HiveMind-matrix run --botname "$botname" --matrixtoken "$matrixtoken" --matrixhost "$matrixhost" --room "$room"
 }
 
 if ! hivemind_set_identity "$VOICE_SAT_KEY" "$VOICE_SAT_PASSWORD" "$VOICE_SAT_HOST" "$VOICE_SAT_PORT"; then

--- a/matrix-bot/files/requirements.txt
+++ b/matrix-bot/files/requirements.txt
@@ -1,4 +1,3 @@
-# 0.1.1 declares an impossible python-matrixbot>=0.4.0 (that project only ever
-# published up to 0.0.7), so the release is uninstallable. 0.1.2a2 corrects the
-# pin to python-matrixbot>=0.0.7.
-hivemind-matrix-bridge==0.1.2a2
+# 0.1.1 declares an impossible python-matrixbot>=0.4.0 (that project only ever published up to
+# 0.0.7), so that release is uninstallable; the floor keeps resolution at 0.1.2a2 or newer.
+hivemind-matrix-bridge>=0.1.2a2

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["python"],
+      "allowedVersions": "<3.14",
+      "description": "ovos-releases tests up to Python 3.13; several plugins declare <3.14"
+    }
   ]
 }

--- a/satellite/Dockerfile
+++ b/satellite/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG TAG=alpha
 ARG REGISTRY=docker.io/smartgic
 ARG SOUND_BASE_IMAGE=${REGISTRY}/hivemind-sound-base:${TAG}
@@ -20,14 +20,20 @@ LABEL org.opencontainers.image.title="HiveMind Voice Satellite" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="${REGISTRY}/hivemind-sound-base:${TAG}" \
+      org.opencontainers.image.base.name="${SOUND_BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${REGISTRY}/hivemind-satellite:${TAG}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
-ARG ALPHA=false
+ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
+ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
+
+# The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD
+# checksums the remote file, so the layer cache busts exactly when the constraints change.
+ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${CHANNEL}.txt /tmp/constraints.txt
 
 USER root
 
@@ -42,10 +48,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
  && apt-get install -o Dpkg::Options::="--force-confold" -y --no-install-recommends --no-install-suggests \
       libatomic1 libasound2-dev libportaudio2 portaudio19-dev libpulse-dev build-essential python3-dev mpv \
- && (uv pip install -f 'https://whl.smartgic.io/' tflite_runtime || echo "tflite_runtime unavailable; skipping install") \
- && PRERELEASE="${UV_PRERELEASE}" \
- && if [ "${ALPHA}" = "true" ]; then PRERELEASE="allow"; fi \
- && uv pip install --prerelease="${PRERELEASE}" -r /tmp/requirements.txt \
+ && uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt -r /tmp/requirements.txt \
  && mkdir -p \
       "/home/${USER}/.config/hivemind" \
       "/home/${USER}/.config/mycroft" \
@@ -53,6 +56,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       "/home/${USER}/.local/state/mycroft" \
       "/home/${USER}/.local/share/mycroft/listener" \
       "/home/${USER}/.local/share/precise-lite/mycroft" \
+      "/home/${USER}/.local/share/vosk" \
  && chown "${USER}:${USER}" -R "/home/${USER}" \
  && apt-get --purge remove -y libasound2-dev portaudio19-dev libpulse-dev build-essential python3-dev \
  && apt-get --purge autoremove -y \

--- a/satellite/files/entrypoint.sh
+++ b/satellite/files/entrypoint.sh
@@ -32,7 +32,7 @@ fi
 
 # Check if _identify file exists and leverage it
 if test -f "$identity_file"; then
-    hivemind-voice-sat
+    exec hivemind-voice-sat
 else
-    hivemind-voice-sat --key "$VOICE_SAT_KEY" --password "$VOICE_SAT_PASSWORD" --host "$VOICE_SAT_HOST" --port "$VOICE_SAT_PORT" --siteid "$HIVEMIND_SITEID"
+    exec hivemind-voice-sat --key "$VOICE_SAT_KEY" --password "$VOICE_SAT_PASSWORD" --host "$VOICE_SAT_HOST" --port "$VOICE_SAT_PORT" --siteid "$HIVEMIND_SITEID"
 fi

--- a/satellite/files/requirements.txt
+++ b/satellite/files/requirements.txt
@@ -10,5 +10,8 @@ ovos-PHAL-plugin-ipgeo
 ovos-stt-plugin-chromium
 ovos-tts-plugin-polly
 ovos-vad-plugin-webrtcvad
-ovos-ww-plugin-openwakeword
-ovos-ww-plugin-precise-lite
+# tflite-based wake-word plugins (openwakeword, precise-lite) cannot install on
+# Python 3.13 (no cp313 tflite-runtime wheel; openwakeword also pins numpy<2);
+# precise-onnx runs the same precise models on onnxruntime, vosk needs no models.
+ovos-ww-plugin-precise-onnx
+ovos-ww-plugin-vosk

--- a/sound-base/Dockerfile
+++ b/sound-base/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 # sound-base/Dockerfile
 # Multi-stage to compile pyalsaaudio without shipping toolchains.
 
@@ -18,6 +18,7 @@ ARG BUILD_DATE=unknown
 ARG VERSION=unknown
 ARG IMAGE_REF=${REGISTRY}/hivemind-sound-base:${TAG}
 ARG GIT_SHA=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI sound base image" \
       org.opencontainers.image.description="Sound base layer for audio related images" \
@@ -31,7 +32,8 @@ LABEL org.opencontainers.image.title="HiveMind OCI sound base image" \
       org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${IMAGE_REF}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
 ARG USER=hivemind
 USER root

--- a/webchat/Dockerfile
+++ b/webchat/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 ARG TAG=alpha
 ARG REGISTRY=docker.io/smartgic
 ARG BASE_IMAGE=${REGISTRY}/hivemind-base:${TAG}
@@ -20,14 +20,20 @@ LABEL org.opencontainers.image.title="HiveMind OCI WebChat" \
       org.opencontainers.image.vendor="HiveMind" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.authors="HiveMind Community" \
-      org.opencontainers.image.base.name="${REGISTRY}/hivemind-base:${TAG}" \
+      org.opencontainers.image.base.name="${BASE_IMAGE}" \
       org.opencontainers.image.url="https://jarbashivemind.github.io/HiveMind-community-docs/" \
       org.opencontainers.image.ref.name="${REGISTRY}/hivemind-webchat:${TAG}" \
-      org.opencontainers.image.revision="${GIT_SHA}"
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      io.openvoiceos.constraints.ref="${OVOS_RELEASES_REF}"
 
-ARG ALPHA=false
+ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
+ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
+
+# The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD
+# checksums the remote file, so the layer cache busts exactly when the constraints change.
+ADD --chmod=0644 https://raw.githubusercontent.com/OpenVoiceOS/ovos-releases/${OVOS_RELEASES_REF}/constraints-${CHANNEL}.txt /tmp/constraints.txt
 
 COPY files/requirements.txt /tmp/requirements.txt
 
@@ -36,12 +42,13 @@ USER root
 SHELL ["/bin/bash", "-c"]
 
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
-    PRERELEASE="${UV_PRERELEASE}" \
- && if [ "${ALPHA}" = "true" ]; then PRERELEASE="allow"; fi \
- && uv pip install --prerelease="${PRERELEASE}" -r /tmp/requirements.txt \
+    uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt -r /tmp/requirements.txt \
  && rm -rf /tmp/* /var/tmp/*
 
 USER "$USER"
+
+HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=30s \
+  CMD curl -sf http://127.0.0.1:9090/ > /dev/null || exit 1
 
 ENTRYPOINT ["hivemind-webchat"]
 

--- a/webchat/files/requirements.txt
+++ b/webchat/files/requirements.txt
@@ -1,1 +1,1 @@
-hivemind-webchat==0.2.2
+hivemind-webchat>=0.2.2


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

First of three PRs porting the [ovos-docker automation overhaul](https://github.com/OpenVoiceOS/ovos-docker/releases/tag/v2.0.0) to hivemind-docker.

## Constraints replace manual pins

Every install now runs against `constraints-<channel>.txt` from [OpenVoiceOS/ovos-releases](https://github.com/OpenVoiceOS/ovos-releases) (`ADD` checksums the remote file, so the layer cache busts exactly when the pins move), and every image carries an `io.openvoiceos.constraints.ref` label.

The manual pins all carried comments about hivemind-core 4.6.0a2 not yet supporting ovos-bus-client 2.x — the constraints set has moved past that: it resolves `hivemind-core >=4.13.13a1` **together with** `ovos-bus-client >=2.8.4a2` as one mutually-consistent set, so `hivemind-core==4.6.0a2`, `hivemind-redis-database==0.1.0a7` and `hivemind-cli==0.5.0a4` are removed (CI's `pip check` smoke test proves consistency per image). Client-side packages (`hivemind-voice-sat`, `hivemind-cli`, bridges) are not in the constraints file and resolve to their newest release under the channel's prerelease policy; `hivemind-matrix-bridge` keeps a `>=0.1.2a2` floor (0.1.1 is uninstallable upstream).

## Images

- **base**: digest-pinned `python:3.13.15-slim-trixie` behind a single `PYTHON_IMAGE` arg (one Renovate bump updates FROM + label), uv as a pinned static binary instead of an unpinned `pip install uv`, `setuptools<82` (pkg_resources consumers, same pin as ovos-installer), `UV_COMPILE_BYTECODE=1` and `MALLOC_ARENA_MAX=2`
- **entrypoints** now `exec` their service — PID 1 gets SIGTERM, so `docker stop` is a clean shutdown instead of a 10s timeout + SIGKILL
- **healthchecks**: the listener probes its own websocket handshake on `${HIVEMIND_PORT:-5678}` (and finally `EXPOSE 5678`), webchat/chatroom probe their HTTP ports
- `--prerelease` comes straight from the `UV_PRERELEASE` arg (alpha → allow); the redundant `ALPHA` arg is gone

## Bake

`tags()`/`cache_from()`/`cache_to()` helpers, build cache on GHCR (`ghcr.io/jarbashivemind/hivemind-docker-cache`, one tag per image+channel), optional `MIRROR_REGISTRY` (CI will use `ghcr.io/jarbashivemind/hivemind-docker`, sub-namespaced so packages can never collide with other JarbasHiveMind repos' packages), and `OVOS_RELEASES_REF` plumbed to every target. Renovate now pins digests and GitHub Action SHAs.

Next PRs: the CI workflows (thin callers of ovos-docker's reusable `build-images.yml`, giving alpha/testing/stable + `latest`=stable multi-arch publishing), then compose hardening + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Container images now use more consistent, reproducible build settings and release-channel dependency constraints.
  - Services receive improved health monitoring, helping container platforms detect unavailable chatroom, listener, and webchat services.
  - Service processes now handle shutdown and restart signals more reliably.

- **Compatibility**
  - Several components can use newer compatible dependency releases instead of being restricted to older versions.
  - Release channels are now applied consistently across supported services.

- **Maintenance**
  - Build metadata and caching have been standardized to support more reliable image publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->