### PR TITLE
feat(compose): init, bounded logs, hardened services, documented env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+compose/.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,9 +37,11 @@ the wire protocol and specs live in the architecture docs.
   extra packages listed in a mounted `satellite.list`, detects PulseAudio vs
   PipeWire, and execs `hivemind-voice-sat` with credentials from environment
   variables.
-- `compose/docker-compose.yml` + `compose/.env-example` — the only compose
-  service defined today is the voice satellite, pointed at an external
-  hub via `VOICE_SAT_HOST`/`VOICE_SAT_PORT`.
+- `compose/` — one compose file per deployment: the hub
+  (`docker-compose.yml`: listener + cli), the voice satellite
+  (`docker-compose.satellite.yml`, pointed at a hub via
+  `VOICE_SAT_HOST`/`VOICE_SAT_PORT`), and the chatroom / webchat / matrix-bot
+  bridges. `.env-example` documents every variable with placeholders.
 - There is no test suite, no linter config, and no CI workflow in this repo —
   say so plainly rather than inventing one. Validate a change by actually
   building the affected image (`docker build -t test ./listener` etc.) and,
@@ -113,8 +115,8 @@ the wire protocol and specs live in the architecture docs.
   itself only ever references `${VAR}` interpolations, never literal
   credentials — if a change needs a concrete value for local testing, put it
   in a local `.env` (untracked) and add the variable to `.env-example` with a
-  placeholder, never a real one. There is no `.gitignore` in this repo yet;
-  do not commit a real `.env` file.
+  placeholder, never a real one. `.gitignore` excludes `.env`;
+  still, never commit a real `.env` file.
 - **First-run credential bootstrap is the hub's job, not this repo's.** The
   satellite container only consumes an already-issued `VOICE_SAT_KEY` /
   `VOICE_SAT_PASSWORD` pair via environment variables passed at container

--- a/README.md
+++ b/README.md
@@ -55,6 +55,30 @@ This command will:
 
 Grab a coffee—or a pint of honey—while Docker works its magic.
 
+## Image Tags
+
+Every image is published for `linux/amd64` and `linux/arm64` under [docker.io/smartgic](https://hub.docker.com/u/smartgic), one tag per channel — the same channels as [ovos-installer](https://github.com/OpenVoiceOS/ovos-installer):
+
+| Tag | Channel | Versions come from |
+| --- | ------- | ------------------ |
+| `alpha` | pre-releases | `constraints-alpha.txt` in [ovos-releases](https://github.com/OpenVoiceOS/ovos-releases) |
+| `testing` | release candidates | `constraints-testing.txt` |
+| `stable` | releases | `constraints-stable.txt` |
+| `latest` | alias of `stable` | — |
+
+A dated `<channel>-YYYYMMDD` tag is kept for each publish, and every image is also pushed to the GHCR mirror `ghcr.io/jarbashivemind/hivemind-docker` (no pull-rate limit) and signed with cosign. If a container misbehaves after a pull, pin the previous day's dated tag and open an issue.
+
+## Automation
+
+| Workflow | When | What |
+| -------- | ---- | ---- |
+| PR build | every pull request | dry-builds the images the PR touches, both architectures |
+| Publish on push | merge on `dev` | rebuilds + publishes what changed, every channel |
+| Publish on constraints change | hourly | rebuilds images whose pinned packages moved in ovos-releases |
+| Weekly rebuild | Tuesdays | full rebuild per channel, so base-OS fixes always land |
+
+The workflows are thin callers of ovos-docker's reusable [`build-images.yml`](https://github.com/OpenVoiceOS/ovos-docker/blob/dev/.github/workflows/build-images.yml) — images are verified (manifest, per-arch smoke run) before the channel tag moves, and what each channel was built from is recorded on the `build-state` branch.
+
 ## Build Images (Buildx Bake)
 
 Builds are handled via Docker Buildx Bake (`docker-bake.hcl` and `scripts/bake.sh`). Direct
@@ -75,9 +99,12 @@ Defaults are defined in `docker-bake.hcl` and `scripts/bake.sh`:
 - `REGISTRY` (default `docker.io/smartgic`)
 - `TAG` and `VERSION` (default `alpha`)
 - `LATEST_TAG` (default `latest`, only applied when `TAG=stable`)
-- `CHANNEL` (default `alpha`)
+- `CHANNEL` (default `alpha`): which `constraints-<channel>.txt` pins the installs
+- `OVOS_RELEASES_REF` (default `main`): git ref of ovos-releases to take the constraints from
 - `PLATFORMS` (default `linux/amd64,linux/arm64`)
-- `UV_PRERELEASE` (default `allow`)
+- `UV_PRERELEASE` (default `allow`): uv prerelease policy (`never` outside alpha)
+- `MIRROR_REGISTRY` (default empty; CI uses `ghcr.io/jarbashivemind/hivemind-docker`)
+- `CACHE_REPO`/`CACHE_TO`: GHCR build cache (`hivemind-docker-cache`); leave `CACHE_TO` empty locally
 - `ENSURE_BINFMT` (default `auto`, set `true` to force or `false` to skip)
 - `BUILDER` (default `hivemind-bake`)
 

--- a/compose/.env-example
+++ b/compose/.env-example
@@ -1,22 +1,33 @@
+# Copy to .env next to the compose file you use, fill in real values, never commit it.
 
+# Which image tag to run: alpha, testing, stable or latest
+VERSION=alpha
+TZ=Etc/UTC
+
+# Container user (matches the image's user)
+HIVEMIND_USER=hivemind
+
+# Hub (docker-compose.yml): host folders for hivemind configuration and share
 HIVEMIND_CONFIG_FOLDER=~/hivemind/config
 HIVEMIND_SHARE_FOLDER=~/hivemind/share
-HIVEMIND_USER=hivemind
-HIVEMIND_SITEID=voice-sat-1
-MATRIX_BOT_NAME=hivemind-bot
-MATRIX_HOST=https://matrix.org
-MATRIX_ROOM="#hivemind-bots:matrix.org"
-MATRIX_TOKEN=syt_XXXX
-OVOS_CONFIG_FOLDER=~/ovos/config
-TZ=America/Montreal
-VERSION=alpha
-VOICE_SAT_KEY=95b774f1e85c2ea8e8a80ac2c5d09c6b
-VOICE_SAT_PASSWORD=255203b3c8a7e59de1d60441a55d4f48
-VOICE_SAT_HOST=ws://192.168.100.55
+
+# Satellite (docker-compose.satellite.yml): credentials issued by the hub (hivemind-core add-client)
+VOICE_SAT_KEY=changeme
+VOICE_SAT_PASSWORD=changeme
+VOICE_SAT_HOST=ws://hub.example.org
 VOICE_SAT_PORT=5678
-# chatroom reads SAT_* (the rest of the stack reads VOICE_SAT_*)
-SAT_KEY=95b774f1e85c2ea8e8a80ac2c5d09c6b
-SAT_PASSWORD=255203b3c8a7e59de1d60441a55d4f48
-SAT_HOST=ws://192.168.100.55
-SAT_PORT=5678
+HIVEMIND_SITEID=default
+OVOS_CONFIG_FOLDER=~/hivemind/mycroft
 XDG_RUNTIME_DIR=/run/user/1000
+
+# Chatroom (docker-compose.chatroom.yml)
+SAT_KEY=changeme
+SAT_PASSWORD=changeme
+SAT_HOST=ws://hub.example.org
+SAT_PORT=5678
+
+# Matrix bot (docker-compose.matrix-bot.yml)
+MATRIX_BOT_NAME=hivemind
+MATRIX_TOKEN=changeme
+MATRIX_HOST=https://matrix.org
+MATRIX_ROOM="#myroom:matrix.org"

--- a/compose/docker-compose.chatroom.yml
+++ b/compose/docker-compose.chatroom.yml
@@ -1,22 +1,30 @@
 ---
-version: "3.9"
-
 x-podman: &podman
+  init: true
   userns_mode: keep-id
   security_opt:
     - "label=disable"
+
+x-hardened: &hardened
+  userns_mode: keep-id
+  init: true
+  security_opt:
+    - "label=disable"
+    - "no-new-privileges:true"
+  cap_drop:
+    - ALL
 
 x-logging: &default-logging
   driver: json-file
   options:
     mode: non-blocking
     max-buffer-size: 4m
-    max-size: "200m"
-    max-file: "1"
+    max-size: "10m"
+    max-file: "3"
 
 services:
   hivemind_chatroom:
-    <<: *podman
+    <<: *hardened
     container_name: hivemind_chatroom
     hostname: hivemind_chatroom
     restart: unless-stopped

--- a/compose/docker-compose.matrix-bot.yml
+++ b/compose/docker-compose.matrix-bot.yml
@@ -1,11 +1,19 @@
 ---
-version: "3.9"
-
 x-podman:
   &podman
+  init: true
   userns_mode: keep-id
   security_opt:
     - "label=disable"
+
+x-hardened: &hardened
+  userns_mode: keep-id
+  init: true
+  security_opt:
+    - "label=disable"
+    - "no-new-privileges:true"
+  cap_drop:
+    - ALL
 
 x-logging:
   &default-logging
@@ -13,12 +21,12 @@ x-logging:
   options:
     mode: non-blocking
     max-buffer-size: 4m
-    max-size: "200m"
-    max-file: "1"
+    max-size: "10m"
+    max-file: "3"
 
 services:
   hivemind_matrix_bot:
-    <<: *podman
+    <<: *hardened
     container_name: hivemind_matrix_bot
     hostname: hivemind_matrix_bot
     restart: unless-stopped

--- a/compose/docker-compose.satellite.yml
+++ b/compose/docker-compose.satellite.yml
@@ -1,11 +1,19 @@
 ---
-version: "3.9"
-
 x-podman:
   &podman
+  init: true
   userns_mode: keep-id
   security_opt:
     - "label=disable"
+
+x-hardened: &hardened
+  userns_mode: keep-id
+  init: true
+  security_opt:
+    - "label=disable"
+    - "no-new-privileges:true"
+  cap_drop:
+    - ALL
 
 x-logging:
   &default-logging
@@ -13,8 +21,8 @@ x-logging:
   options:
     mode: non-blocking
     max-buffer-size: 4m
-    max-size: "200m"
-    max-file: "1"
+    max-size: "10m"
+    max-file: "3"
 
 volumes:
   ovos_models:
@@ -44,6 +52,7 @@ services:
       VOICE_SAT_PASSWORD: $VOICE_SAT_PASSWORD
       VOICE_SAT_HOST: $VOICE_SAT_HOST
       VOICE_SAT_PORT: $VOICE_SAT_PORT
+      HIVEMIND_SITEID: ${HIVEMIND_SITEID:-default}
       XDG_RUNTIME_DIR: $XDG_RUNTIME_DIR
     devices:
       - /dev/snd
@@ -57,7 +66,7 @@ services:
       - ${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse:ro
 
   hivemind_cli:
-    <<: *podman
+    <<: *hardened
     container_name: hivemind_cli
     hostname: hivemind_cli
     restart: unless-stopped

--- a/compose/docker-compose.webchat.yml
+++ b/compose/docker-compose.webchat.yml
@@ -1,11 +1,19 @@
 ---
-version: "3.9"
-
 x-podman:
   &podman
+  init: true
   userns_mode: keep-id
   security_opt:
     - "label=disable"
+
+x-hardened: &hardened
+  userns_mode: keep-id
+  init: true
+  security_opt:
+    - "label=disable"
+    - "no-new-privileges:true"
+  cap_drop:
+    - ALL
 
 x-logging:
   &default-logging
@@ -13,12 +21,12 @@ x-logging:
   options:
     mode: non-blocking
     max-buffer-size: 4m
-    max-size: "200m"
-    max-file: "1"
+    max-size: "10m"
+    max-file: "3"
 
 services:
   hivemind_webchat:
-    <<: *podman
+    <<: *hardened
     container_name: hivemind_webchat
     hostname: hivemind_webchat
     restart: unless-stopped

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -1,11 +1,19 @@
 ---
-version: "3.9"
-
 x-podman:
   &podman
+  init: true
   userns_mode: keep-id
   security_opt:
     - "label=disable"
+
+x-hardened: &hardened
+  userns_mode: keep-id
+  init: true
+  security_opt:
+    - "label=disable"
+    - "no-new-privileges:true"
+  cap_drop:
+    - ALL
 
 x-logging:
   &default-logging
@@ -13,8 +21,8 @@ x-logging:
   options:
     mode: non-blocking
     max-buffer-size: 4m
-    max-size: "200m"
-    max-file: "1"
+    max-size: "10m"
+    max-file: "3"
 
 volumes:
   hivemind_local_state:
@@ -23,7 +31,7 @@ volumes:
     
 services:
   hivemind_listener:
-    <<: *podman
+    <<: *hardened
     container_name: hivemind_listener
     hostname: hivemind_listener
     restart: unless-stopped
@@ -42,9 +50,9 @@ services:
       - hivemind_local_state:/home/${HIVEMIND_USER}/.local/state/hivemind
 
   hivemind_cli:
-    <<: *podman
-    container_name: ovos_hivemind_cli
-    hostname: ovos_hivemind_cli
+    <<: *hardened
+    container_name: hivemind_cli
+    hostname: hivemind_cli
     restart: unless-stopped
     image: docker.io/smartgic/hivemind-cli:${VERSION}
     logging: *default-logging


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

Third PR of the automation port from ovos-docker (after #22 and the CI workflows PR).

Every compose service now runs with an init process as PID 1 and rotated `3×10MB` logs instead of a single file that grows to 200MB. Services that never touch audio hardware — listener, cli, chatroom, webchat, matrix-bot — drop all capabilities and set `no-new-privileges`; the satellite keeps its device and socket mounts unchanged. The obsolete `version:` key is gone.

Two real gaps surfaced while auditing: the satellite entrypoint has always read `HIVEMIND_SITEID`, but no compose file passed it (now passed, defaulting to `default`), and the hub's cli container was named `ovos_hivemind_cli` — a copy-paste leftover, now `hivemind_cli`.

`compose/.env-example` previously contained real-looking credentials and a LAN address; it now documents every variable used across the five compose files with placeholders, grouped per deployment. The README gains the channel tag table (`alpha`/`testing`/`stable`/`latest`, dated tags, GHCR mirror, cosign) and an overview of the automation, and AGENTS.md follows the compose layout it describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)