### PR TITLE
fix(ci): pass Docker Hub secrets explicitly to the cross-org reusable workflow

### DIFF
--- a/.github/workflows/on-constraints.yml
+++ b/.github/workflows/on-constraints.yml
@@ -83,4 +83,8 @@ jobs:
       ovos_releases_ref: ${{ matrix.ref }}
       push: true
       mirror_registry: ghcr.io/jarbashivemind/hivemind-docker
-    secrets: inherit
+    secrets:
+      # secrets: inherit does not cross organization boundaries (the reusable
+      # workflow lives in OpenVoiceOS); they must be passed explicitly.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -60,4 +60,8 @@ jobs:
       targets: ${{ needs.select.outputs.targets }}
       push: true
       mirror_registry: ghcr.io/jarbashivemind/hivemind-docker
-    secrets: inherit
+    secrets:
+      # secrets: inherit does not cross organization boundaries (the reusable
+      # workflow lives in OpenVoiceOS); they must be passed explicitly.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -54,4 +54,8 @@ jobs:
       targets: ${{ needs.select.outputs.targets }}
       push: false
       mirror_registry: ghcr.io/jarbashivemind/hivemind-docker
-    secrets: inherit
+    secrets:
+      # secrets: inherit does not cross organization boundaries (the reusable
+      # workflow lives in OpenVoiceOS); they must be passed explicitly.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -50,4 +50,8 @@ jobs:
       targets: default
       push: true
       mirror_registry: ghcr.io/jarbashivemind/hivemind-docker
-    secrets: inherit
+    secrets:
+      # secrets: inherit does not cross organization boundaries (the reusable
+      # workflow lives in OpenVoiceOS); they must be passed explicitly.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

The bootstrap dispatch ([run 33332789719](https://github.com/JarbasHiveMind/hivemind-docker/actions/runs/33332789719)) failed every build with `push=true but DOCKERHUB_USERNAME/DOCKERHUB_TOKEN are not set`: `secrets: inherit` only passes secrets to reusable workflows **within the same organization or enterprise**, and `build-images.yml` lives in OpenVoiceOS. The secrets exist in this repository — they just never crossed the org boundary.

`build-images.yml` already declares both `workflow_call` secrets (optional), so the four callers now pass them explicitly, which works across organizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)