### PR TITLE
fix(images): declare OVOS_RELEASES_REF before the LABEL that uses it

### DIFF
--- a/chatroom/Dockerfile
+++ b/chatroom/Dockerfile
@@ -10,6 +10,7 @@ ARG GIT_SHA=unknown
 
 ARG BUILD_DATE=unknown
 ARG VERSION=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI Chatroom" \
       org.opencontainers.image.description="This simple WebUI allows you to securely interact with your OpenVoiceOS instance through HiveMind." \
@@ -28,7 +29,6 @@ LABEL org.opencontainers.image.title="HiveMind OCI Chatroom" \
 
 ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
-ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
 
 # The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -10,6 +10,7 @@ ARG GIT_SHA=unknown
 
 ARG BUILD_DATE=unknown
 ARG VERSION=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI CLI image" \
       org.opencontainers.image.description="Command line to interact with HiveMind" \
@@ -28,7 +29,6 @@ LABEL org.opencontainers.image.title="HiveMind OCI CLI image" \
 
 ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
-ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
 
 # The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD

--- a/listener/Dockerfile
+++ b/listener/Dockerfile
@@ -10,6 +10,7 @@ ARG GIT_SHA=unknown
 
 ARG BUILD_DATE=unknown
 ARG VERSION=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI HiveMind listener" \
       org.opencontainers.image.description="Start listening for HiveMind connections" \
@@ -28,7 +29,6 @@ LABEL org.opencontainers.image.title="HiveMind OCI HiveMind listener" \
 
 ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
-ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
 
 # The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD

--- a/matrix-bot/Dockerfile
+++ b/matrix-bot/Dockerfile
@@ -10,6 +10,7 @@ ARG GIT_SHA=unknown
 
 ARG BUILD_DATE=unknown
 ARG VERSION=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI Matrix bot" \
       org.opencontainers.image.description="Connecting in a Matrix chatroom to HiveMind" \
@@ -28,7 +29,6 @@ LABEL org.opencontainers.image.title="HiveMind OCI Matrix bot" \
 
 ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
-ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
 
 # The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD

--- a/satellite/Dockerfile
+++ b/satellite/Dockerfile
@@ -10,6 +10,7 @@ ARG GIT_SHA=unknown
 
 ARG BUILD_DATE=unknown
 ARG VERSION=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind Voice Satellite" \
       org.opencontainers.image.description="Voice Satellite connect to a HiveMind Listener in order to speak with the Open Voice OS message bus" \
@@ -28,7 +29,6 @@ LABEL org.opencontainers.image.title="HiveMind Voice Satellite" \
 
 ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
-ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
 
 # The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD

--- a/webchat/Dockerfile
+++ b/webchat/Dockerfile
@@ -10,6 +10,7 @@ ARG GIT_SHA=unknown
 
 ARG BUILD_DATE=unknown
 ARG VERSION=unknown
+ARG OVOS_RELEASES_REF=main
 
 LABEL org.opencontainers.image.title="HiveMind OCI WebChat" \
       org.opencontainers.image.description="Connecting to the HiveMind with javascript reference implementation" \
@@ -28,7 +29,6 @@ LABEL org.opencontainers.image.title="HiveMind OCI WebChat" \
 
 ARG CHANNEL=alpha
 ARG UV_PRERELEASE=never
-ARG OVOS_RELEASES_REF=main
 ARG USER=hivemind
 
 # The channel's resolved, mutually-consistent version set from OpenVoiceOS/ovos-releases. ADD


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

In the bootstrap ([run 33333248595](https://github.com/JarbasHiveMind/hivemind-docker/actions/runs/33333248595)) every leaf image failed verification with `platform/label check failed` while base and sound-base passed. A Dockerfile `ARG` only exists after its declaration: the six service Dockerfiles declared `OVOS_RELEASES_REF` *after* the `LABEL` block that expands it, so `io.openvoiceos.constraints.ref` was baked empty and never matched the expected ovos-releases commit. The declaration moves above the labels (one per stage covers everything below it).

Merging this triggers `on-push`, which rebuilds exactly these six images for alpha, testing and stable — completing the bootstrap that published base and sound-base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)