### PR TITLE
fix(satellite): precise-onnx as per-channel extra so the stable channel builds

### DIFF
--- a/satellite/Dockerfile
+++ b/satellite/Dockerfile
@@ -49,6 +49,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
  && apt-get install -o Dpkg::Options::="--force-confold" -y --no-install-recommends --no-install-suggests \
       libatomic1 libasound2-dev libportaudio2 portaudio19-dev libpulse-dev build-essential python3-dev mpv \
  && uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt -r /tmp/requirements.txt \
+ # precise-onnx needs ovos-plugin-manager>=1, which the stable channel does not have yet
+ # (its ovos-audio-plugin-mpv still pins opm<0.10); vosk covers wake word where this skips
+ && (uv pip install --prerelease="${UV_PRERELEASE}" -c /tmp/constraints.txt ovos-ww-plugin-precise-onnx \
+     || echo "ovos-ww-plugin-precise-onnx unavailable on this channel; vosk wake word remains") \
  && mkdir -p \
       "/home/${USER}/.config/hivemind" \
       "/home/${USER}/.config/mycroft" \

--- a/satellite/files/requirements.txt
+++ b/satellite/files/requirements.txt
@@ -11,7 +11,7 @@ ovos-stt-plugin-chromium
 ovos-tts-plugin-polly
 ovos-vad-plugin-webrtcvad
 # tflite-based wake-word plugins (openwakeword, precise-lite) cannot install on
-# Python 3.13 (no cp313 tflite-runtime wheel; openwakeword also pins numpy<2);
-# precise-onnx runs the same precise models on onnxruntime, vosk needs no models.
-ovos-ww-plugin-precise-onnx
+# Python 3.13 (no cp313 tflite-runtime wheel; openwakeword also pins numpy<2).
+# vosk works on every channel; precise-onnx is channel-dependent and installed
+# by the Dockerfile where the channel's constraints allow it.
 ovos-ww-plugin-vosk


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

The bootstrap's stable builds ([run 33333248595](https://github.com/JarbasHiveMind/hivemind-docker/actions/runs/33333248595)) failed resolving the satellite: `constraints-stable` pins `ovos-audio-plugin-mpv>=0.2.1`, which requires `ovos-plugin-manager<0.10`, while **every** `ovos-ww-plugin-precise-onnx` release needs `opm>=1` — unsatisfiable, and one failing target fails the whole channel's bake.

`precise-onnx` moves out of `requirements.txt` into a tolerated install step: it lands where the channel's constraints allow it (alpha, testing) and skips with a log line elsewhere; `ovos-ww-plugin-vosk` stays as the wake word available on every channel. Verified locally that the remaining satellite set resolves against `constraints-stable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)