### PR TITLE
chore(ci): bump the reusable workflow to build-images.yml@v2.0.2

### DIFF
--- a/.github/workflows/on-constraints.yml
+++ b/.github/workflows/on-constraints.yml
@@ -76,7 +76,7 @@ jobs:
       max-parallel: 1
       matrix:
         include: ${{ fromJSON(needs.select.outputs.matrix) }}
-    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.1
+    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.2
     with:
       channel: ${{ matrix.channel }}
       targets: ${{ matrix.targets }}

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -54,7 +54,7 @@ jobs:
       max-parallel: 1
       matrix:
         channel: [alpha, testing, stable]
-    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.1
+    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.2
     with:
       channel: ${{ matrix.channel }}
       targets: ${{ needs.select.outputs.targets }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,7 +48,7 @@ jobs:
     name: alpha (dry run)
     needs: select
     if: needs.select.outputs.count != '0'
-    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.1
+    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.2
     with:
       channel: alpha
       targets: ${{ needs.select.outputs.targets }}

--- a/.github/workflows/scheduled-rebuild.yml
+++ b/.github/workflows/scheduled-rebuild.yml
@@ -44,7 +44,7 @@ jobs:
   rebuild:
     name: ${{ needs.pick.outputs.channel }}
     needs: pick
-    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.1
+    uses: OpenVoiceOS/ovos-docker/.github/workflows/build-images.yml@v2.0.2
     with:
       channel: ${{ needs.pick.outputs.channel }}
       targets: default

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A dated `<channel>-YYYYMMDD` tag is kept for each publish, and every image is al
 | Publish on constraints change | hourly | rebuilds images whose pinned packages moved in ovos-releases |
 | Weekly rebuild | Tuesdays | full rebuild per channel, so base-OS fixes always land |
 
-The workflows are thin callers of ovos-docker's reusable [`build-images.yml@v2.0.1`](https://github.com/OpenVoiceOS/ovos-docker/blob/v2.0.1/.github/workflows/build-images.yml) — the exact CI that builds the ovos-docker images. An image is verified (manifest, per-arch smoke run) before its channel tag moves, published to Docker Hub and the GHCR mirror, cosign-signed, and what each channel was built from is recorded on the `build-state` branch. Verify a signature with:
+The workflows are thin callers of ovos-docker's reusable [`build-images.yml@v2.0.2`](https://github.com/OpenVoiceOS/ovos-docker/blob/v2.0.2/.github/workflows/build-images.yml) — the exact CI that builds the ovos-docker images. An image is verified (manifest, per-arch smoke run) before its channel tag moves, published to Docker Hub and the GHCR mirror, cosign-signed, and what each channel was built from is recorded on the `build-state` branch. Verify a signature with:
 
 ```bash
 cosign verify \


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

[ovos-docker v2.0.2](https://github.com/OpenVoiceOS/ovos-docker/releases/tag/v2.0.2) pins cosign to v2.6.5 — v3 writes signatures only as OCI referrer bundles, so the `sha256-<digest>.sig` tag the Docker Hub signature copy relies on never existed and every channel merge job ended red after publishing. It also makes smoke-test failure annotations report the failing command's actual output. Version bump only, in the four callers and the README link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)