### PR TITLE
feat(perf): compiled bytecode in sound-base, memory ceilings and hub OOM shield

### DIFF
--- a/compose/.env-example
+++ b/compose/.env-example
@@ -31,3 +31,7 @@ MATRIX_BOT_NAME=hivemind
 MATRIX_TOKEN=changeme
 MATRIX_HOST=https://matrix.org
 MATRIX_ROOM="#myroom:matrix.org"
+
+# Optional memory ceilings per service class
+STANDARD_MEMORY_LIMIT=1G
+LIGHT_MEMORY_LIMIT=512M

--- a/compose/docker-compose.chatroom.yml
+++ b/compose/docker-compose.chatroom.yml
@@ -14,6 +14,22 @@ x-hardened: &hardened
   cap_drop:
     - ALL
 
+x-resource-limits: &resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${STANDARD_MEMORY_LIMIT:-1G}
+      reservations:
+        memory: 64M
+
+x-light-resource-limits: &light-resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${LIGHT_MEMORY_LIMIT:-512M}
+      reservations:
+        memory: 32M
+
 x-logging: &default-logging
   driver: json-file
   options:
@@ -24,7 +40,7 @@ x-logging: &default-logging
 
 services:
   hivemind_chatroom:
-    <<: *hardened
+    <<: [*hardened, *light-resource-limits]
     container_name: hivemind_chatroom
     hostname: hivemind_chatroom
     restart: unless-stopped

--- a/compose/docker-compose.matrix-bot.yml
+++ b/compose/docker-compose.matrix-bot.yml
@@ -15,6 +15,22 @@ x-hardened: &hardened
   cap_drop:
     - ALL
 
+x-resource-limits: &resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${STANDARD_MEMORY_LIMIT:-1G}
+      reservations:
+        memory: 64M
+
+x-light-resource-limits: &light-resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${LIGHT_MEMORY_LIMIT:-512M}
+      reservations:
+        memory: 32M
+
 x-logging:
   &default-logging
   driver: json-file
@@ -26,7 +42,7 @@ x-logging:
 
 services:
   hivemind_matrix_bot:
-    <<: *hardened
+    <<: [*hardened, *light-resource-limits]
     container_name: hivemind_matrix_bot
     hostname: hivemind_matrix_bot
     restart: unless-stopped

--- a/compose/docker-compose.satellite.yml
+++ b/compose/docker-compose.satellite.yml
@@ -15,6 +15,22 @@ x-hardened: &hardened
   cap_drop:
     - ALL
 
+x-resource-limits: &resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${STANDARD_MEMORY_LIMIT:-1G}
+      reservations:
+        memory: 64M
+
+x-light-resource-limits: &light-resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${LIGHT_MEMORY_LIMIT:-512M}
+      reservations:
+        memory: 32M
+
 x-logging:
   &default-logging
   driver: json-file
@@ -37,7 +53,7 @@ volumes:
 
 services:
   hivemind_satellite:
-    <<: *podman
+    <<: [*podman, *resource-limits]
     container_name: hivemind_satellite
     hostname: hivemind_satellite
     restart: unless-stopped
@@ -66,7 +82,7 @@ services:
       - ${XDG_RUNTIME_DIR}/pulse:${XDG_RUNTIME_DIR}/pulse:ro
 
   hivemind_cli:
-    <<: *hardened
+    <<: [*hardened, *light-resource-limits]
     container_name: hivemind_cli
     hostname: hivemind_cli
     restart: unless-stopped

--- a/compose/docker-compose.webchat.yml
+++ b/compose/docker-compose.webchat.yml
@@ -15,6 +15,22 @@ x-hardened: &hardened
   cap_drop:
     - ALL
 
+x-resource-limits: &resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${STANDARD_MEMORY_LIMIT:-1G}
+      reservations:
+        memory: 64M
+
+x-light-resource-limits: &light-resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${LIGHT_MEMORY_LIMIT:-512M}
+      reservations:
+        memory: 32M
+
 x-logging:
   &default-logging
   driver: json-file
@@ -26,7 +42,7 @@ x-logging:
 
 services:
   hivemind_webchat:
-    <<: *hardened
+    <<: [*hardened, *light-resource-limits]
     container_name: hivemind_webchat
     hostname: hivemind_webchat
     restart: unless-stopped

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -15,6 +15,22 @@ x-hardened: &hardened
   cap_drop:
     - ALL
 
+x-resource-limits: &resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${STANDARD_MEMORY_LIMIT:-1G}
+      reservations:
+        memory: 64M
+
+x-light-resource-limits: &light-resource-limits
+  deploy:
+    resources:
+      limits:
+        memory: ${LIGHT_MEMORY_LIMIT:-512M}
+      reservations:
+        memory: 32M
+
 x-logging:
   &default-logging
   driver: json-file
@@ -31,7 +47,9 @@ volumes:
     
 services:
   hivemind_listener:
-    <<: *hardened
+    <<: [*hardened, *resource-limits]
+    # the hub is the last thing the kernel should kill
+    oom_score_adj: -500
     container_name: hivemind_listener
     hostname: hivemind_listener
     restart: unless-stopped
@@ -50,7 +68,7 @@ services:
       - hivemind_local_state:/home/${HIVEMIND_USER}/.local/state/hivemind
 
   hivemind_cli:
-    <<: *hardened
+    <<: [*hardened, *light-resource-limits]
     container_name: hivemind_cli
     hostname: hivemind_cli
     restart: unless-stopped

--- a/sound-base/Dockerfile
+++ b/sound-base/Dockerfile
@@ -83,7 +83,9 @@ USER root
 SHELL ["/bin/bash", "-c"]
 
 COPY --from=builder /tmp/wheels /tmp/wheels
+# PYTHONDONTWRITEBYTECODE keeps runtime layers clean, so compile at build time instead
 RUN python -m pip install --no-index --find-links=/tmp/wheels pyalsaaudio \
+ && python -m compileall -q "/home/hivemind/.venv/lib" \
  && rm -rf /tmp/wheels
 
 ARG USER=hivemind


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

Closes the last optimization gaps against ovos-docker's images:

- **sound-base shipped uncompiled bytecode**: it installs `pyalsaaudio` with plain pip under `PYTHONDONTWRITEBYTECODE=1`, so nothing was compiled and every container start paid the parse cost — `compileall` now runs at build time (`uv` installs already compile via `UV_COMPILE_BYTECODE=1`).
- **Memory ceilings**, env-driven like ovos-docker: `STANDARD_MEMORY_LIMIT` (default 1G) for listener and satellite, `LIGHT_MEMORY_LIMIT` (default 512M) for cli and the bridges, with small reservations; documented in `.env-example`.
- **`oom_score_adj: -500` on the listener** — the hub every satellite and bridge connects to is the last thing the kernel should kill.

Everything else already matches: digest-pinned Python 3.13.15 base with pinned static `uv`, `MALLOC_ARENA_MAX=2`, bytecode at build time, toolchains purged in-layer, docs/locales stripped, init + capped logs + `cap_drop` (#23), healthchecks on the network services (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)