### PR TITLE
fix(webchat): floor at 0.3.1a0, where the console script got its current name

### DIFF
--- a/webchat/files/requirements.txt
+++ b/webchat/files/requirements.txt
@@ -1,1 +1,4 @@
-hivemind-webchat>=0.2.2
+# 0.2.2 (the only stable release) names its console script HiveMind-webchat; the
+# entrypoint calls hivemind-webchat, introduced in 0.3.1a0 — so the floor sits at
+# the rename and every channel installs the working alpha until a newer stable lands.
+hivemind-webchat>=0.3.1a0


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 via Claude Code — NOT human-reviewed. Verify before acting.

The testing rebuild ([run 33337010616](https://github.com/JarbasHiveMind/hivemind-docker/actions/runs/33337010616)) published and signed every image except webchat: its smoke run found no `hivemind-webchat` binary. The testing channel resolves stable releases, and 0.2.2 — the only stable `hivemind-webchat` — names its console script `HiveMind-webchat`; the lowercase name the ENTRYPOINT calls arrived in 0.3.1a0. So the image could never have started on testing/stable — the verify gate did its job.

The floor moves to `>=0.3.1a0` (a prerelease specifier, so every channel installs the working alpha until a newer stable release lands), same pattern as matrix-bot's floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)